### PR TITLE
DD: Support uploading DD Modlog to Hastebin

### DIFF
--- a/workspace sir vivor/commands.js
+++ b/workspace sir vivor/commands.js
@@ -2037,6 +2037,20 @@ exports.commands = {
 		}
 		dd.updateModlog(user.name + " did .rmparts " + target);
 	},
+	
+	ddlog: function (target, user, room) {
+		if (!user.hasRank('survivor', '%')) return;
+		if (!("data" in dd.modlog)) return;
+		let buffer = '';
+		for (let i = 0; i < dd.modlog.data.length; i++) {
+			buffer += dd.modlog.data[i] + '\n';
+		}
+		Tools.uploadToHastebin(buffer, (success, link) => {
+			if (success) user.say(link);
+			else user.say(this.room, 'Error connecting to hastebin.');
+        	});
+	},
+	
 	testroom: function (target, user, room) {
 		if (!user.hasRank('survivor', '@')) return;
 		Rooms.get('survivor').say("/makegroupchat testing");

--- a/workspace sir vivor/commands.js
+++ b/workspace sir vivor/commands.js
@@ -2047,7 +2047,7 @@ exports.commands = {
 		}
 		Tools.uploadToHastebin(buffer, (success, link) => {
 			if (success) user.say(link);
-			else user.say(this.room, 'Error connecting to hastebin.');
+			else user.say('Error connecting to hastebin.');
         	});
 	},
 	

--- a/workspace sir vivor/tools.js
+++ b/workspace sir vivor/tools.js
@@ -157,6 +157,28 @@ class Tools {
 	turnFirstUpper(str) {
 		return str[0].toUpperCase() + str.substr(1).toLowerCase();
 	}
+	uploadToHastebin(toUpload, callback) {
+		let reqOpts = {
+			hostname: "hastebin.com",
+			method: "POST",
+			path: '/documents'
+		};
+		let req = require('https').request(reqOpts, function (res) {
+			res.on('data', function (chunk) {
+				try {
+					var linkStr = "hastebin.com/" + JSON.parse(chunk.toString())['key'];
+					if (typeof callback === "function") callback(true, linkStr);
+				} catch (e) {
+					if (typeof callback === "function") callback(false, e);
+				}
+			});
+		});
+		req.on('error', function (e) {
+			if (typeof callback === "function") callback(false, e);
+		});
+		req.write(toUpload);
+		req.end();
+	};
 }
 
 let tools = new Tools();

--- a/workspace sir vivor/tools.js
+++ b/workspace sir vivor/tools.js
@@ -166,7 +166,7 @@ class Tools {
 		let req = require('https').request(reqOpts, function (res) {
 			res.on('data', function (chunk) {
 				try {
-					var linkStr = "hastebin.com/" + JSON.parse(chunk.toString())['key'];
+					let linkStr = "hastebin.com/" + JSON.parse(chunk.toString())['key'];
 					if (typeof callback === "function") callback(true, linkStr);
 				} catch (e) {
 					if (typeof callback === "function") callback(false, e);


### PR DESCRIPTION
Usage: `.ddlog`

Uploads the list of DD modlog actions to Hastebin, separating by line for readability.