### PR TITLE
Updated HST.js

### DIFF
--- a/workspace sir vivor/games/HST.js
+++ b/workspace sir vivor/games/HST.js
@@ -56,9 +56,9 @@ class HST extends Games.Game {
 		}
 		this.actions.clear();
 		this.numActions = 0;
-		if (this.seekerLives === 1) {
+		if (this.seekerLives === 1 || this.getRemainingPlayerCount() === 2) {
 			this.locations = {};
-			let newlocs = Tools.sample(Object.keys(locations), 3);
+			let newlocs = Tools.sample(Object.keys(locations), 2);
 			for (let i = 0; i < newlocs.length; i++) {
 				this.locations[newlocs[i]] = locations[newlocs[i]];
 			}


### PR DESCRIPTION
When either the seeker has 1 life left or there is only one hider left then the spots get reduced to 2 rather than 3