### PR TITLE
Sylv/Jolt update

### DIFF
--- a/workspace sir vivor/games/Eeveelutions.js
+++ b/workspace sir vivor/games/Eeveelutions.js
@@ -160,13 +160,6 @@ class Eevee extends Games.Game {
 			}
 		}
 		if (this.doingb) {
-			if (this.eevee2 === 'Jolteon') {
-				if (this.eevee1 === 'Sylveon') {
-					this.roll2 = '2d50';
-				} else {
-					this.roll2 = '2d65';
-				}
-			}
 			if (this.eevee2 === 'Leafeon') {
 				this.roll2 += 25
 			}


### PR DESCRIPTION
Sylveon only affects Jolteon's roll when Jolteon is the attacker, not when Jolteon is the defender as well, thus, that condition has been removed.