### PR TITLE
add a system for upkeeping a back up for dd.json

### DIFF
--- a/workspace sir vivor/classes/ExternalDoc.js
+++ b/workspace sir vivor/classes/ExternalDoc.js
@@ -1,0 +1,88 @@
+const { google } = require('googleapis');
+const path = require('path');
+const fs = require('fs');
+process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(__dirname, '../credentials.json');
+
+function getFileContent(filePath) {
+    let fileContent;
+    try {
+        fileContent = fs.readFileSync(filePath, 'utf8');
+    } catch (err) {
+        console.error(err);
+    }
+    return fileContent;
+}
+
+class ExternalDoc {
+    authenticateAPI() {
+        const auth = new google.auth.GoogleAuth({
+            keyfilePath: path.join(__dirname, 'credentials.json'),
+            scopes: ['https://www.googleapis.com/auth/documents']
+        });
+
+        const docs = google.docs({ version: 'v1', auth });
+
+        return docs;
+    }
+
+    deleteAllTextRequest(requests, endOfDoc) {
+        requests.push({
+            deleteContentRange: {
+                range: {
+                    startIndex: 1,
+                    endIndex: endOfDoc - 1,
+                },
+            },
+        });
+    }
+
+    insertTextRequest(requests, newText) {
+        requests.push({
+            insertText: {
+                endOfSegmentLocation: {},
+                text: newText,
+            },
+        });
+    }
+
+    doRequests(documentId, requests, docs) {
+        return docs.documents.batchUpdate({
+            documentId: documentId,
+            requestBody: { requests },
+        }).then((updateResponse) => {
+                console.log(updateResponse.data);
+                return updateResponse.data;
+            })
+    }
+
+    copyToBackup(filePath, LbBackupdocId) {
+        // authenticate service account
+        const docs = this.authenticateAPI();
+
+        // put local file's content into a string
+        const newText = getFileContent(filePath);
+
+        // return if string is empty
+        if (newText === 0) return Promise.resolve(); // Return a resolved promise
+
+        // get backup document's endIndex position
+        return docs.documents.get({ documentId: LbBackupdocId })
+            .then((response) => {
+                const endOfDoc = response.data.body.content[1].endIndex;
+
+                // create list of requests
+                const requests = [];
+
+                // request to delete all doc content
+                this.deleteAllTextRequest(requests, endOfDoc);
+
+                // request to insert file's content to doc
+                this.insertTextRequest(requests, newText);
+
+                // carry out requests
+                return this.doRequests(LbBackupdocId, requests, docs);
+            })
+    }
+}
+
+module.exports = ExternalDoc;

--- a/workspace sir vivor/config-example.js
+++ b/workspace sir vivor/config-example.js
@@ -106,3 +106,6 @@ exports.punishvals = {
  
 //This key is used to deliver requests from Google Spreadsheets. Used by the wifi room.
 exports.googleapikey = '';
+
+// Used for identifying the google doc to make requests to. Used as a dd.json backup
+exports.backupLBDocID = '';

--- a/workspace sir vivor/main.js
+++ b/workspace sir vivor/main.js
@@ -29,6 +29,7 @@ require('sugar');
 global.colors = require('colors');
 const logging = require('./utilities/logging.js');
 const fs = require('fs');
+const path = require('path');
 
 global.toId = function(text) {
 	return ('' + text).toLowerCase().replace(/[^a-z0-9]+/g, '');
@@ -217,5 +218,20 @@ global.connect = function (retry) {
 	ws.connect(conStr, Config.secprotocols);
 };
 
-global.connect();
+//Set up back up a backup for LB points
+const ExternalDoc = require('./classes/ExternalDoc.js');
+const LbFilePath = path.join(__dirname, './databases/dd.json');
+const Backup = new ExternalDoc();
+const interval = 30 * 60 * 1000; // 30 mins in miliseconds
 
+//Initial backup
+Backup.copyToBackup(LbFilePath, Config.backupLBDocID);
+
+//Copies dd.json to backup doc every 30 minutes
+setInterval(() => {
+	Backup.copyToBackup(LbFilePath, Config.backupLBDocID);
+}, interval);
+
+
+//Connect to PS
+global.connect();


### PR DESCRIPTION
added a system to backup dd.json if for some reason it gets erased.

- dd.json is the file that tracks all points, hosts, participations to display on the LB
- new class: ExternalDoc
- uses google docs API
- copies dd.json to a google doc every 30 minutes
- google docs has a useful feature saves all edit history. If a backup get overwritten unintentionally, it can be roll backed.
- Right now there is no .importLbBackup command, so omeone will have to retrieve the backup and then manually cop/paste into Sir Vivors dd.json file, but I plan to add that command next.