### PR TITLE
update pl helper

### DIFF
--- a/workspace sir vivor/games.js
+++ b/workspace sir vivor/games.js
@@ -839,7 +839,8 @@ class PL_Assistant extends GamesManager{
 		this.expandedUser = 'none';
 		this.notes = '';
 		this.playersElim = {};
-		this.hideNotes = false;
+		this.hideNotes = true;
+		this.isSignupTimer = false;
         //this.HTMLPage = new HTMLPage(pageID);
     }
 	joinGame(user){
@@ -852,7 +853,6 @@ class PL_Assistant extends GamesManager{
 			this.players[user.id] = player;
 		} else {
 			this.addPlayer(user);
-			if (this.plToolIsEnabled()) user.say("/msgroom survivor, /sendprivatehtmlbox " + user.id + ", You have joined the Survivor game hosted by " + Games.host.name + "!");
 		}
 		if (typeof this.onJoin === 'function') this.onJoin(user);
 	}
@@ -869,7 +869,6 @@ class PL_Assistant extends GamesManager{
 	leaveGame(user) {
 		if (!(user.id in this.players) || this.players[user.id].eliminated) return;
 		this.removePlayer(user, true);
-		if (this.plToolIsEnabled()) user.say("/msgroom survivor, /sendprivatehtmlbox " + user.id + ", You have left the Survivor game.");
 	}
 	removePlayer(player, flag) {
 			if (!player) return;
@@ -887,17 +886,34 @@ class PL_Assistant extends GamesManager{
 		player.eliminated = false;
 	}
 	getPlayerList() {
-		let pl = "**PL: (" + this.playerCount + ")**: ";
 		let names = [];
 		for (let i in this.players) {
 			if(this.players[i].eliminated != true) names.push(this.players[i].name);
 		}
-		pl += names.join(", ");
-		return pl;
+		let result = '';
+		result += names.join(", ");
+		return result;
 	}
 	displayPlayerList() {
-		let pl = this.getPlayerList();
-		user.say(pl);
+		let pl = "**PL: (" + this.playerCount + ")**: " + this.getPlayerList();
+		return pl;
+	}
+	shuffleList(pl) {
+		let stuff = pl.split(",");
+		this.shuffle(stuff);
+		let str = "<i>" + stuff.join(', ').replace(/>/g, "&gt;").replace(/</g, "&lt;").trim() + "</i>";
+		return str;
+	}
+	shuffle(array) {
+		for (let i = array.length - 1; i > 0; i--) {
+			let j = Math.floor(Math.random() * (i + 1));
+			[array[i], array[j]] = [array[j], array[i]];
+		}
+	}
+	pickPlayer(pl) {
+		let stuff = pl.split(",");
+		let str = "<em>We randomly picked:</em> " + Tools.sample(stuff).replace(/>/g, "&gt;").replace(/</g, "&lt;").trim();
+		return str;
 	}
 	clearPlayerList() {
 		this.players= [];
@@ -939,6 +955,9 @@ class PL_Assistant extends GamesManager{
 	}
 	saveNotes(notes){
 		this.notes = notes;
+	}
+	signupsTimer(room){
+		this.say(room, "Signups are closed!");
 	}
 }
 

--- a/workspace sir vivor/parser.js
+++ b/workspace sir vivor/parser.js
@@ -323,7 +323,7 @@ global.parse = exports.parse = {
 				}
 				return;
 			}
-			else if (Games.host && room.id === 'survivor' && Games.playerListToolEnabled) Parse.say(room, '/sendprivatehtmlbox, ' + user.id + ', Signups for this game are closed');
+			else if (Games.host && room.id === 'survivor') Parse.say(room, '/sendprivatehtmlbox, ' + user.id + ', Signups for this game are closed');
 			else if (room.game) room.game.join(user);
 		} 
 		else if (message.substr(0, 7) === '/me out' && (room.game || Games.host)) {


### PR DESCRIPTION
hosts can manage pl helper via .pl
 .pl displays pl
 .pl shuffle - shuffles pl
 .pl pick - picks a raondom user from pl
 .pl elim, [user] - removes user from pl
 .pl close - closes signups
 .pl open - opens signups
 .pl timer, [time] - closes signups after a time
 .pl add, [user] - adds a player to the pl [not finished]
.pl and its commands can be used at anytime, it does not need to be enabled
notes area hidden by default
turned off private join/leave messages for players 